### PR TITLE
Add missing payment_ticket_type enum value for side conversation remi…

### DIFF
--- a/server/models/Client.js
+++ b/server/models/Client.js
@@ -238,7 +238,7 @@ const clientSchema = new mongoose.Schema({
   // Payment and Review Tracking
   payment_ticket_type: {
     type: String,
-    enum: ['document_request', 'processing_wait', 'manual_review', 'auto_approved', 'no_creditors_found', 'creditor_contact_initiated']
+    enum: ['document_request', 'processing_wait', 'manual_review', 'auto_approved', 'no_creditors_found', 'creditor_contact_initiated', 'document_reminder_side_conversation']
   },
   payment_processed_at: Date,
   document_request_sent_at: Date,


### PR DESCRIPTION
…nders

- Add 'document_reminder_side_conversation' to payment_ticket_type enum
- Fixes database validation error when saving clients with side conversation reminders
- Resolves "is not a valid enum value" error

🤖 Generated with [Claude Code](https://claude.ai/code)