### PR TITLE
Fix creditor reference number in first letter Word template

### DIFF
--- a/server/services/firstRoundDocumentGenerator.js
+++ b/server/services/firstRoundDocumentGenerator.js
@@ -152,7 +152,8 @@ class FirstRoundDocumentGenerator {
                 creditor.sender_name || 
                 "Unbekannter Gläubiger",
             
-            "Aktenzeichen des Credtiors": creditor.creditor_reference || 
+            "Aktenzeichen des Credtiors": creditor.reference_number ||
+                creditor.creditor_reference || 
                 creditor.reference || 
                 creditor.aktenzeichen || 
                 "Nicht verfügbar",


### PR DESCRIPTION
- Added reference_number as primary field for creditor reference
- The field 'reference_number' from creditor schema was missing in fallback chain
- This fixes 'Nicht verfügbar' showing instead of actual creditor reference numbers
- Template now correctly displays creditor file numbers in generated documents